### PR TITLE
Releasing memory between trajectory mmCIF outputs and introducing the frame.cif file

### DIFF
--- a/include/BiopolymerClass.h
+++ b/include/BiopolymerClass.h
@@ -515,7 +515,6 @@ public :
     const bool  isRNA    (const Biopolymer & inputBiopolymer) ;
     const bool  isDNA    (const Biopolymer & inputBiopolymer) ;
     const bool  isProtein(const Biopolymer & inputBiopolymer, bool endCaps) ;
-    void        resetAllPdbFileNames(String newPdbFileNames);
     void        loadSequencesFromPdb(String inPDBFilename,bool proteinCapping, const String & chainsPrefix , const bool tempRenumberPdbResidues  , const bool useNACappingHydroxyls); 
     const PdbStructure & getPdbStructure(String fileName);
     void        printBiopolymerInfo() ;

--- a/include/CifOutput.h
+++ b/include/CifOutput.h
@@ -18,7 +18,7 @@ namespace SimTK
     {
 #ifdef GEMMI_USAGE
         void writeOutCif   ( gemmi::Structure outStruct, std::string fileName, std::vector < std::pair < std::string, std::string > > remarks );
-        void reWriteOutCif ( gemmi::Model gModel, std::string modelName, ParameterReader& myParameterReader, const CompoundSystem& system, bool firstInStage );
+        void reWriteOutCif ( gemmi::Model gModel, std::string modelName, std::string fileName, ParameterReader& myParameterReader, const CompoundSystem& system, bool firstInStage );
 #endif
     }                                                 // End namespace CIFOut
 }                                                     // End namespace SimTK

--- a/include/CifOutput.h
+++ b/include/CifOutput.h
@@ -8,13 +8,17 @@
 #include <stdlib.h>
 #include "molmodel/internal/Compound.h"
 
+#include "PeriodicPdbAndEnergyWriter.h"
+#include "SimTKsimbody.h"
+
 
 namespace SimTK
 {
     namespace CIFOut
     {
 #ifdef GEMMI_USAGE
-        void writeOutCif ( gemmi::Structure outStruct, std::string fileName, std::vector < std::pair < std::string, std::string > > remarks );
+        void writeOutCif   ( gemmi::Structure outStruct, std::string fileName, std::vector < std::pair < std::string, std::string > > remarks );
+        void reWriteOutCif ( gemmi::Model gModel, std::string modelName, ParameterReader& myParameterReader, const CompoundSystem& system, bool firstInStage );
 #endif
     }                                                 // End namespace CIFOut
 }                                                     // End namespace SimTK

--- a/include/ParameterReader.h
+++ b/include/ParameterReader.h
@@ -81,9 +81,9 @@ public:
     bool   addTestSpring;
     bool   useCIFFileFormat;
 #ifdef GEMMI_USAGE
-    gemmi::Structure gemmiCifTrajectoryFile;
     std::vector< std::pair < std::string, std::string > > trajectoryFileRemarks;
     std::vector< std::pair < std::string, std::string > > lastFileRemarks;
+    bool gemmi_isFirstInStage;
 #endif
     bool   alignmentForcesIsGapped;
     double alignmentForcesGapPenalty;

--- a/include/Repel.h
+++ b/include/Repel.h
@@ -168,8 +168,7 @@ public:
     * Initialize Biopolymers starting position
     */
     int  initializeBiopolymersAndCustomMolecules();
-    int  initializeBiopolymersAndCustomMoleculesWithoutResettingPdbFileNames(); // calls initializeBiopolymersAndCustomMolecules(CompoundSystem , FALSE);
-    int  initializeBiopolymersAndCustomMolecules(CompoundSystem & system, bool resetAllPdbFileNames = true); // The second parameter, if left empty, defaults to True and means that each chain's prior pdbFileName is overwritten.
+    int  initializeBiopolymersAndCustomMolecules(CompoundSystem & system); 
 
     /**
     * Initialize one Biopolymer identified by its chain

--- a/src/BiopolymerClass.cpp
+++ b/src/BiopolymerClass.cpp
@@ -4192,21 +4192,6 @@ void BiopolymerClassContainer::loadSequencesFromPdb(const String inPDBFileName,c
     //printBiopolymerSequenceInfo(updBiopolymerClass("g").myBiopolymer);
 };
 
-void BiopolymerClassContainer::resetAllPdbFileNames ( String newPdbFileNames )
-{
-    //================================================ Iterate through all biopolymers
-    map<const String, BiopolymerClass>::iterator it;
-    map<const String, BiopolymerClass>::iterator next;
-
-    next                                              = this->biopolymerClassMap.begin();
-    while (next != this->biopolymerClassMap.end())
-    {
-        it = next;
-        (it->second).setPdbFileName                   ( newPdbFileNames );
-        next++;
-    }
-}
-
 void BiopolymerClassContainer::printBiopolymerInfo() {
     map<const String,BiopolymerClass>::iterator biopolymerClassMapIterator = biopolymerClassMap.begin();
     for(biopolymerClassMapIterator = biopolymerClassMap.begin(); biopolymerClassMapIterator != biopolymerClassMap.end(); biopolymerClassMapIterator++) {

--- a/src/CifOutput.cpp
+++ b/src/CifOutput.cpp
@@ -4,8 +4,9 @@
     #define GEMMI_WRITE_IMPLEMENTATION
     #include <gemmi/to_mmcif.hpp>
     #include <gemmi/to_cif.hpp>
+    #include <gemmi/gz.hpp>
 
-void  SimTK::CIFOut::writeOutCif ( gemmi::Structure outStruct, std::string fileName, std::vector < std::pair < std::string, std::string > > remarks )
+void SimTK::CIFOut::writeOutCif ( gemmi::Structure outStruct, std::string fileName, std::vector < std::pair < std::string, std::string > > remarks )
 {
     //================================================ Create document from the structure with models
     gemmi::cif::Document outDocument                  = gemmi::make_mmcif_document ( outStruct );
@@ -52,4 +53,80 @@ void  SimTK::CIFOut::writeOutCif ( gemmi::Structure outStruct, std::string fileN
     return ;
     
 }
+
+void SimTK::CIFOut::reWriteOutCif ( gemmi::Model gModel, std::string modelName, ParameterReader& myParameterReader, const CompoundSystem& system, bool firstInStage )
+{
+    //================================================ Try to read in the file
+    if ( firstInStage )
+    {
+        //============================================ File does not exist, create it.
+        gemmi::Structure myTrajectoryOutputFile;
+        
+        //============================================ Add model name
+        myTrajectoryOutputFile.name                   = modelName;
+        
+        //============================================ Save model to structure
+        myTrajectoryOutputFile.models.push_back       ( gModel );
+
+        //============================================ Set Gemmi structure internal values based on model information
+        gemmi::setup_entities                         ( myTrajectoryOutputFile );
+        gemmi::assign_label_seq_id                    ( myTrajectoryOutputFile, true );
+        gemmi::assign_subchains                       ( myTrajectoryOutputFile, true );
+        
+        //============================================ Add sequence to entities
+        int compoundNumber                            = 1;
+        for (SimTK::CompoundSystem::CompoundIndex c(0); c < system.getNumCompounds(); ++c)
+        {
+            //======================================== Print log
+            std::cout <<__FILE__<<":"<<__LINE__<<" c = "<<c<< " compoundNumber = "<<compoundNumber <<std::endl;
+            
+            //======================================== Get sequence for compound
+            std::string compSeq                       = (myParameterReader.myBiopolymerClassContainer.getBiopolymerClassMap ())[myParameterReader.myBiopolymerClassContainer.updBiopolymerClass(compoundNumber-1).getChainID()].getSequence();
+            
+            //======================================== For each structure entity
+            for ( unsigned int enIt = 0; enIt < static_cast<unsigned int> ( myTrajectoryOutputFile.entities.size() ); enIt++ )
+            {
+                //==================================== If entity name = MMB chain ID
+                if ( myTrajectoryOutputFile.entities.at(enIt).name == myParameterReader.myBiopolymerClassContainer.updBiopolymerClass(compoundNumber-1).getChainID() )
+                {
+                    //================================ Copy sequence
+                    myTrajectoryOutputFile.entities.at(enIt).full_sequence.clear();
+                    for ( unsigned int sqIt = 0; sqIt < static_cast<unsigned int> ( compSeq.length() ); sqIt++ )
+                    {
+                        myTrajectoryOutputFile.entities.at(enIt).full_sequence.emplace_back ( std::to_string ( compSeq[sqIt] ) );
+                    }
+                }
+            }
+            
+            //======================================== Update compound number
+            compoundNumber++;
+        }
+        
+        //============================================ Write out the file
+        writeOutCif ( myTrajectoryOutputFile, myParameterReader.outTrajectoryFileName, myParameterReader.trajectoryFileRemarks );
+        
+    }
+    else
+    {
+        //============================================ File does exist, read it, update it and re-write it
+        gemmi::cif::Document doc                      = gemmi::cif::read ( gemmi::MaybeGzipped ( myParameterReader.outTrajectoryFileName ) );
+        gemmi::Structure myTrajectoryOutputFile       = gemmi::make_structure ( doc );
+        
+        //============================================ Add model to structure
+        myTrajectoryOutputFile.models.push_back       ( gModel );
+
+        //============================================ Set Gemmi structure internal values based on model information
+        gemmi::setup_entities                         ( myTrajectoryOutputFile );
+        gemmi::assign_label_seq_id                    ( myTrajectoryOutputFile, true );
+        gemmi::assign_subchains                       ( myTrajectoryOutputFile, true );
+        
+        //============================================ Write out the file
+        writeOutCif ( myTrajectoryOutputFile, myParameterReader.outTrajectoryFileName, myParameterReader.trajectoryFileRemarks );
+    }
+    
+    //============================================ Done
+    return ;
+    
+}
+
 #endif

--- a/src/CifOutput.cpp
+++ b/src/CifOutput.cpp
@@ -54,7 +54,7 @@ void SimTK::CIFOut::writeOutCif ( gemmi::Structure outStruct, std::string fileNa
     
 }
 
-void SimTK::CIFOut::reWriteOutCif ( gemmi::Model gModel, std::string modelName, ParameterReader& myParameterReader, const CompoundSystem& system, bool firstInStage )
+void SimTK::CIFOut::reWriteOutCif ( gemmi::Model gModel, std::string modelName, std::string fileName, ParameterReader& myParameterReader, const CompoundSystem& system, bool firstInStage )
 {
     //================================================ Try to read in the file
     if ( firstInStage )
@@ -103,13 +103,13 @@ void SimTK::CIFOut::reWriteOutCif ( gemmi::Model gModel, std::string modelName, 
         }
         
         //============================================ Write out the file
-        writeOutCif ( myTrajectoryOutputFile, myParameterReader.outTrajectoryFileName, myParameterReader.trajectoryFileRemarks );
+        writeOutCif ( myTrajectoryOutputFile, fileName, myParameterReader.trajectoryFileRemarks );
         
     }
     else
     {
         //============================================ File does exist, read it, update it and re-write it
-        gemmi::cif::Document doc                      = gemmi::cif::read ( gemmi::MaybeGzipped ( myParameterReader.outTrajectoryFileName ) );
+        gemmi::cif::Document doc                      = gemmi::cif::read ( gemmi::MaybeGzipped ( fileName ) );
         gemmi::Structure myTrajectoryOutputFile       = gemmi::make_structure ( doc );
         
         //============================================ Add model to structure
@@ -121,7 +121,7 @@ void SimTK::CIFOut::reWriteOutCif ( gemmi::Model gModel, std::string modelName, 
         gemmi::assign_subchains                       ( myTrajectoryOutputFile, true );
         
         //============================================ Write out the file
-        writeOutCif ( myTrajectoryOutputFile, myParameterReader.outTrajectoryFileName, myParameterReader.trajectoryFileRemarks );
+        writeOutCif ( myTrajectoryOutputFile, fileName, myParameterReader.trajectoryFileRemarks );
     }
     
     //============================================ Done

--- a/src/PeriodicPdbAndEnergyWriter.cpp
+++ b/src/PeriodicPdbAndEnergyWriter.cpp
@@ -109,12 +109,16 @@ void SimTK::PeriodicPdbAndEnergyWriter::handleEvent(State& state, Real accuracy,
         }
     }
     
+#ifdef GEMMI_USAGE
+    SimTK::CIFOut::reWriteOutCif                      ( gModel, strName, "frame.cif", myParameterReader, system, true );
+#else
     filebuf fb;
     fb.open("frame.pdb",ios::out);
     std::ostream  fbstream (&fb);
     PdbAtom::setWriteFullPrecisionLocation(true); // get higher precision from file that might be reused for reading.
     for (SimTK::CompoundSystem::CompoundIndex c(0); c < system.getNumCompounds(); ++c)
         (system.getCompound(c)).writePdb(state, fbstream,Transform(Vec3(0)));
+#endif
 
     //scf added time reporting 
     time_t rawtime;
@@ -160,7 +164,7 @@ void SimTK::PeriodicPdbAndEnergyWriter::handleEvent(State& state, Real accuracy,
         myParameterReader.trajectoryFileRemarks.push_back ( std::pair < std::string, std::string > ( "3", "" ) );
         
         //============================================ Write out CIF
-        SimTK::CIFOut::reWriteOutCif                  ( gModel, strName, myParameterReader, system, myParameterReader.gemmi_isFirstInStage );
+        SimTK::CIFOut::reWriteOutCif                  ( gModel, strName, myParameterReader.outTrajectoryFileName, myParameterReader, system, myParameterReader.gemmi_isFirstInStage );
         if ( myParameterReader.gemmi_isFirstInStage ) { myParameterReader.gemmi_isFirstInStage = false; }
 #endif
     }

--- a/src/PeriodicPdbAndEnergyWriter.cpp
+++ b/src/PeriodicPdbAndEnergyWriter.cpp
@@ -108,17 +108,22 @@ void SimTK::PeriodicPdbAndEnergyWriter::handleEvent(State& state, Real accuracy,
             (system.getCompound(c)).writePdb(state, outputStream,Transform(Vec3(0)));//, nextAtomSerialNumber);
         }
     }
-    
+
+    if ( myParameterReader.useCIFFileFormat )
+    {
 #ifdef GEMMI_USAGE
-    SimTK::CIFOut::reWriteOutCif                      ( gModel, strName, "frame.cif", myParameterReader, system, true );
-#else
-    filebuf fb;
-    fb.open("frame.pdb",ios::out);
-    std::ostream  fbstream (&fb);
-    PdbAtom::setWriteFullPrecisionLocation(true); // get higher precision from file that might be reused for reading.
-    for (SimTK::CompoundSystem::CompoundIndex c(0); c < system.getNumCompounds(); ++c)
-        (system.getCompound(c)).writePdb(state, fbstream,Transform(Vec3(0)));
+        SimTK::CIFOut::reWriteOutCif                  ( gModel, strName, "frame.cif", myParameterReader, system, true );
 #endif
+    }
+    else
+    {
+        filebuf fb;
+        fb.open("frame.pdb",ios::out);
+        std::ostream  fbstream (&fb);
+        PdbAtom::setWriteFullPrecisionLocation(true); // get higher precision from file that might be reused for reading.
+        for (SimTK::CompoundSystem::CompoundIndex c(0); c < system.getNumCompounds(); ++c)
+            (system.getCompound(c)).writePdb(state, fbstream,Transform(Vec3(0)));
+    }
 
     //scf added time reporting 
     time_t rawtime;

--- a/src/Repel.cpp
+++ b/src/Repel.cpp
@@ -373,19 +373,13 @@ ConstrainedDynamics::~ConstrainedDynamics()
 void ConstrainedDynamics::initializeDumm(){
     _parameterReader->configureDumm(_dumm);
 }
-int  ConstrainedDynamics::initializeBiopolymersAndCustomMoleculesWithoutResettingPdbFileNames()
-{
-    return initializeBiopolymersAndCustomMolecules(_system, bool(false));
-}
+
 int  ConstrainedDynamics::initializeBiopolymersAndCustomMolecules()
 {
-    return initializeBiopolymersAndCustomMolecules(_system, bool(true)); // second argument does not need to be specified, defaults to true. But seems safer this way.
+    return initializeBiopolymersAndCustomMolecules(_system);
 }
-// Argument resetAllPdbFileNames defaults to True (see header).
-int  ConstrainedDynamics::initializeBiopolymersAndCustomMolecules(CompoundSystem & system, bool resetAllPdbFileNames ){
-    //================================================ Depending on settings, set the PDB file name to CIF instead of PDB
-    if (resetAllPdbFileNames) {_parameterReader->myBiopolymerClassContainer.resetAllPdbFileNames ( _parameterReader->previousFrameFileName );}
-    
+
+int  ConstrainedDynamics::initializeBiopolymersAndCustomMolecules(CompoundSystem & system ){
     _parameterReader->moleculeClassContainer.initializeCompounds (_dumm);
     cout<<__FILE__<<":"<<__LINE__<<endl;
     _parameterReader->moleculeClassContainer.matchDefaultConfiguration (_parameterReader->readPreviousFrameFile, _parameterReader->previousFrameFileName, _parameterReader->matchExact,  _parameterReader->matchIdealized  );


### PR DESCRIPTION
This pull request introduces several changes.

1) The trajectory mmCIF files no longer require all trajectories to be kept in memory throughout the stage, but rather only briefly for each new write. 
2) The frame.cif file is now being written instead of frame.pdb if mmCIF output is chosen.

All new changes were tested on several example and all mmCIF files have been successfully read in Coot, Chimera, Pymol and parsed by MAXIT. 