### PR TITLE
Implement safe and efficient file copying routines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,19 @@ if (ENABLE_LEPTON)
     add_definitions(-DLEPTON_ENABLED)
 endif ()
 
+if (UNIX)
+    include(CheckSymbolExists)
+    check_symbol_exists("copy_file_range" "unistd.h" COPY_FILE_RANGE_AVAIL)
+    check_symbol_exists("sendfile" "sys/sendfile.h" SENDFILE_AVAIL)
+
+    if (COPY_FILE_RANGE_AVAIL)
+        add_definitions("-DHAVE_COPY_FILE_RANGE")
+    endif ()
+    if (SENDFILE_AVAIL)
+        add_definitions("-DHAVE_SENDFILE")
+    endif ()
+endif ()
+
 # Sanity checks
 if ((NOT BUILD_SHARED) AND (NOT BUILD_STATIC))
     message(FATAL_ERROR "Neither shared not static build is enabled. There is nothing to build")

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -1,3 +1,4 @@
+// vim: set sw=4 ts=4 sts=4 expandtab :
 /* -------------------------------------------------------------------------- *
  *                           MMB (MacroMoleculeBuilder)                       *
  * -------------------------------------------------------------------------- *
@@ -83,12 +84,13 @@ int myMkdir(const std::string & directoryPath);
 
 int myChdir(const std::string & directoryPath);
 
-#include <iostream>
-#include <cstdio>    // fopen, fclose, fread, fwrite, BUFSIZ
-#include <ctime>
-using namespace std;
+enum class CopyFileResult {
+    Success,
+    Io_Error,
+    No_Space,
+};
 
-int copyFile(const std::string sourceFileName, const std::string destinationFileName ) ;
+CopyFileResult MMB_EXPORT mmbCopyFile(const std::string &sourceFileName, const std::string &destinationFileName);
 
 void MMB_EXPORT closingMessage() ;
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -278,7 +278,7 @@ CopyFileResult mmbCopyFile(const std::string &sourceFileName, const std::string 
 
 #else
 
-static
+inline
 auto getFileSizeFromFd(int fd) {
     struct stat st;
 
@@ -292,7 +292,7 @@ auto getFileSizeFromFd(int fd) {
 
 #ifdef HAVE_COPY_FILE_RANGE
 
-static
+inline
 CopyFileResult mmbCopyFile_copy_file_range(const std::string &sourceFileName, const std::string &destinationFileName) {
     int in = open(sourceFileName.c_str(), O_RDONLY);
     if (in == -1) {
@@ -344,6 +344,7 @@ out:
 
 #endif // HAVE_COPY_FILE_RANGE
 
+inline
 CopyFileResult mmbCopyFile_direct(const std::string &sourceFileName, const std::string &destinationFileName) {
     const size_t BUFSIZE = 8 * 1024;
     auto buf = std::make_unique<char[]>(BUFSIZE);
@@ -419,7 +420,7 @@ out:
 
 #ifdef HAVE_SENDFILE
 
-static
+inline
 CopyFileResult mmbCopyFile_sendfile(const std::string &sourceFileName, const std::string &destinationFileName) {
     int in = open(sourceFileName.c_str(), O_RDONLY);
     if (in == -1) {
@@ -486,7 +487,7 @@ out:
     return retCode;
 }
 
-static
+inline
 std::tuple<bool, int, int, int> getLinuxKernelVersion() {
     struct utsname kernelInfo;
 
@@ -535,7 +536,7 @@ std::tuple<bool, int, int, int> getLinuxKernelVersion() {
     }
 }
 
-static
+inline
 std::function<CopyFileResult (const std::string &, const std::string &)> getMmbCopyFileImpl() {
     auto lnxKernVer = getLinuxKernelVersion();
 


### PR DESCRIPTION
Implementation of platform-specific routines for file copying. All functions implement proper checking of I/O errors and try to take advantage of any acceleration techniques that may be provided by the operating system. If there is no suitable optimized function, a fallback to userspace copy function is provided. macOS-specific optimized function is missing at the moment but I do not have access to a macOS device to implement it.